### PR TITLE
Add TheRock ROCm env script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # strix-halo-testing
 
 WIP Documentation here: https://llm-tracker.info/_TOORG/Strix-Halo
+
+## ROCm environment scripts
+
+Use `rocm-env.sh` for a standard ROCm install in `/opt/rocm`. For nightly ROCm builds from TheRock set up with the path `/home/lhl/therock/rocm-7.0`, source `rocm-therock-env.sh`:
+
+```bash
+source ./rocm-therock-env.sh
+```
+
+This exports HIP and ROCm variables similar to the provided fish configuration.

--- a/rocm-therock-env.sh
+++ b/rocm-therock-env.sh
@@ -1,0 +1,15 @@
+# ---- ROCm nightly from /home/lhl/therock/rocm-7.0 ----
+export ROCM_PATH=/home/lhl/therock/rocm-7.0
+export HIP_PLATFORM=amd
+export HIP_PATH=$ROCM_PATH
+export HIP_CLANG_PATH=$ROCM_PATH/llvm/bin
+export HIP_INCLUDE_PATH=$ROCM_PATH/include
+export HIP_LIB_PATH=$ROCM_PATH/lib
+export HIP_DEVICE_LIB_PATH=$ROCM_PATH/lib/llvm/amdgcn/bitcode
+
+# search paths -- prepend
+export PATH="$ROCM_PATH/bin:$HIP_CLANG_PATH:$PATH"
+export LD_LIBRARY_PATH="$HIP_LIB_PATH:$ROCM_PATH/lib:$ROCM_PATH/lib64:$ROCM_PATH/llvm/lib:${LD_LIBRARY_PATH:-}"
+export LIBRARY_PATH="$HIP_LIB_PATH:$ROCM_PATH/lib:$ROCM_PATH/lib64:${LIBRARY_PATH:-}"
+export CPATH="$HIP_INCLUDE_PATH:${CPATH:-}"
+export PKG_CONFIG_PATH="$ROCM_PATH/lib/pkgconfig:${PKG_CONFIG_PATH:-}"


### PR DESCRIPTION
## Summary
- add `rocm-therock-env.sh` with environment variables for ROCm nightlies
- document both `rocm-env.sh` and `rocm-therock-env.sh`

## Testing
- `bash llm-bench/update-llama.cpp.sh` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_687016260c288332ad9faf95f3251279