### PR TITLE
Fix sensor watcher join error

### DIFF
--- a/llm-bench/llama-cpp-bencher.py
+++ b/llm-bench/llama-cpp-bencher.py
@@ -154,7 +154,7 @@ class SensorWatcher(Thread):
         self.max_temp: Optional[float] = None
         self.max_power: Optional[float] = None
         self._power_samples: List[float] = []
-        self._stop = Event()
+        self._stop_evt = Event()
 
     def _poll(self) -> None:
         out = run_cmd("sensors")
@@ -176,12 +176,12 @@ class SensorWatcher(Thread):
                     pass
 
     def run(self) -> None:
-        while not self._stop.is_set():
+        while not self._stop_evt.is_set():
             self._poll()
             time.sleep(self.interval)
 
     def stop(self) -> None:
-        self._stop.set()
+        self._stop_evt.set()
 
     def avg_power(self) -> Optional[float]:
         if not self._power_samples:


### PR DESCRIPTION
## Summary
- rename the `_stop` attribute in SensorWatcher to avoid clashing with the
  internal `_stop` method from `threading.Thread`

## Testing
- `python -m py_compile llm-bench/llama-cpp-bencher.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch --extra-index-url https://download.pytorch.org/whl/cpu` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68726cafa3248332a3ad477def661f5d