### PR TITLE
Fix Vulkan MoE bench options

### DIFF
--- a/llm-bench/llama-cpp-bencher.py
+++ b/llm-bench/llama-cpp-bencher.py
@@ -432,7 +432,7 @@ def main():
         if backend in ('hip','rocwmma'):
             env_opts.append({'ROCBLAS_USE_HIPBLASLT':'1'})
         b_opts=['']
-        if b=='vulkan' and args.moe:
+        if backend=='vulkan' and args.moe:
             b_opts.append('-b 256')
         for env in env_opts:
             for fa in ('','-fa 1'):


### PR DESCRIPTION
## Summary
- ensure `--moe` benchmarks use `-b 256` with Vulkan backends

## Testing
- `python -m py_compile llm-bench/llama-cpp-bencher.py`

------
https://chatgpt.com/codex/tasks/task_e_6874b7a063788332bdb16cbb2275cdd3