### PR TITLE
Fix memory summary in llama-cpp-bencher

### DIFF
--- a/llm-bench/llama-cpp-bencher.py
+++ b/llm-bench/llama-cpp-bencher.py
@@ -356,7 +356,11 @@ def write_summary(df,out):
             return sub['tokens_per_sec'].iloc[0] if not sub.empty else None
         pp512=_get('pp',512)
         tg128=_get('tg',128)
-        mem=(grp['vram_peak_mib'] + grp['gtt_peak_mib']).max()
+        # Summarize memory based on the increase relative to the start of the
+        # run rather than the absolute peak values.  Using the delta fields
+        # ensures we report memory consumed by the benchmark itself even when
+        # the GPU already had allocations prior to the run.
+        mem=(grp['vram_delta_mib'] + grp['gtt_delta_mib']).max()
         rows.append({'backend':b,'hipblaslt':hiplt,'fa':fa,'b':bf,'pp512':pp512,'tg128':tg128,'mem':mem})
 
     best_pp=max((r['pp512'] or 0 for r in rows),default=0)


### PR DESCRIPTION
## Summary
- compute memory usage with VRAM/GTT deltas in `llama-cpp-bencher.py`

## Testing
- `python -m py_compile llm-bench/llama-cpp-bencher.py`

------
https://chatgpt.com/codex/tasks/task_e_6874b9f6c53483329c7e28b914111063