### PR TITLE
Fix outdir fallback for resummarize

### DIFF
--- a/llm-bench/llama-cpp-bencher.py
+++ b/llm-bench/llama-cpp-bencher.py
@@ -422,7 +422,8 @@ def main():
     if args.outdir:
         out = Path(args.outdir)
     elif args.model:
-        out = Path(Path(args.model).stem)
+        p = Path(args.model)
+        out = Path(p.stem if p.suffix == '.gguf' else p.name)
     else:
         ap.error('must specify --outdir or --model to locate results')
     out.mkdir(exist_ok=True)


### PR DESCRIPTION
## Summary
- patch `llama-cpp-bencher.py` to derive the output folder from
  the whole model argument if no `.gguf` extension is present

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_687e7388b7248332b03e4d80d09de847